### PR TITLE
Download photos with EXIF Metadata

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -85,7 +85,7 @@ func createJSON(item *photoslibrary.MediaItem, fileName string) error {
 func createImage(item *photoslibrary.MediaItem, fileName string) error {
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
-		url := fmt.Sprintf("%v=w%v-h%v-d", item.BaseUrl, item.MediaMetadata.Width, item.MediaMetadata.Height)
+		url := fmt.Sprintf("%v=d", item.BaseUrl)
 		output, err := os.Create(fileName)
 		if err != nil {
 			return err

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -85,7 +85,7 @@ func createJSON(item *photoslibrary.MediaItem, fileName string) error {
 func createImage(item *photoslibrary.MediaItem, fileName string) error {
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
-		url := fmt.Sprintf("%v=w%v-h%v", item.BaseUrl, item.MediaMetadata.Width, item.MediaMetadata.Height)
+		url := fmt.Sprintf("%v=w%v-h%v-d", item.BaseUrl, item.MediaMetadata.Width, item.MediaMetadata.Height)
 		output, err := os.Create(fileName)
 		if err != nil {
 			return err


### PR DESCRIPTION
Download the image retaining all the EXIF metadata except the location metadata (see https://developers.google.com/photos/library/guides/access-media-items#image-base-urls)
Possibly this should be a command line option, but I am not familiar enough with Go to propose a proper change for this (yet). I also cannot easily test this right now, so this is just a proposal :-)