### PR TITLE
Revert "Download photos with EXIF Metadata"

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -85,7 +85,7 @@ func createJSON(item *photoslibrary.MediaItem, fileName string) error {
 func createImage(item *photoslibrary.MediaItem, fileName string) error {
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
-		url := fmt.Sprintf("%v=d", item.BaseUrl)
+		url := fmt.Sprintf("%v=w%v-h%v", item.BaseUrl, item.MediaMetadata.Width, item.MediaMetadata.Height)
 		output, err := os.Create(fileName)
 		if err != nil {
 			return err


### PR DESCRIPTION
Reverts dtylman/gitmoo-goog#6

After checking this, it seems that specifying the `=d` parameter will download the images in a very small resolution. 

