### PR TITLE
Feature file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Usage of ./gitmoo-goog:
         number of items to download on per API call (default 50)
   -throttle int
         Time, in seconds, to wait between API calls (default 5)
+  -folder-format string
+        Time format used for folder paths based on https://golang.org/pkg/time/#Time.Format (default "2016/Janurary")
+  -use-file-name
+        Use file name when uploaded to Google Photos (default off)
 ```
 
 On Linux, running the following is a good practice:

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -94,7 +94,12 @@ func isConflictingFilePath(item *LibraryItem) bool {
 
 // getImageFilePath Get the file path for the image
 func getImageFilePath(item *LibraryItem) string {
-	return filepath.Join(getFolderPath(item.Item), item.UsedFileName);
+	fileName := item.UsedFileName
+	if fileName == "" {
+		fileName = item.Item.FileName
+	}
+
+	return filepath.Join(getFolderPath(item.Item), fileName);
 }
 
 // getJSONFilePath Get the full path to the JSON file representing the MediaItem

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -55,13 +55,12 @@ func (s *LibraryItem) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, []string{}, []string{})
 }
 
+func init() {
+	Options.BackupFolder, _ = os.Getwd()
+}
+
 // getFolderPath Path of the to store JSON and image files for the particular MediaItem
 func getFolderPath(item *photoslibrary.MediaItem) string {
-	backupFolder := Options.BackupFolder
-	if backupFolder == "" {
-		backupFolder, _ = os.Getwd()
-	}
-
 	t, err := time.Parse(time.RFC3339, item.MediaMetadata.CreationTime)
 	year, month := "", ""
 	if err != nil {
@@ -71,7 +70,7 @@ func getFolderPath(item *photoslibrary.MediaItem) string {
 		year = strconv.Itoa(t.Year())
 		month = fmt.Sprintf("%02d", t.Month())
 	}
-	return filepath.Join(backupFolder, year, month)
+	return filepath.Join(Options.BackupFolder, year, month)
 }
 
 // createFileName Get the full path to the image file including what conflict position we are at

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -158,9 +158,9 @@ func getImageFilePath(item *LibraryItem) string {
 func getJSONFilePath(item *photoslibrary.MediaItem) string {
 	if Options.UseFileName {
 		return filepath.Join(getFolderPath(item), "." + item.Id + ".json");
-	} else {
-		return getLegacyPrefixFilePath(item) + ".json"
 	}
+	
+	return getLegacyPrefixFilePath(item) + ".json"
 }
 
 // loadJSON Load the JSON file into LibraryItem

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -248,10 +248,13 @@ func downloadItem(svc *photoslibrary.Service, item *photoslibrary.MediaItem) err
 	if libraryItem == nil {
 		libraryItem = new(LibraryItem)
 		libraryItem.MediaItem = *item
-		libraryItem.UsedFileName = createFileName(libraryItem, 0)
 
-		for conflict := 0; isConflictingFilePath(libraryItem); conflict++ {
+		//Create non-conflicting file name
+		for conflict := 0; true; conflict++ {
 			libraryItem.UsedFileName = createFileName(libraryItem, conflict)
+			if !isConflictingFilePath(libraryItem) {
+				break;
+			}
 		}
 	}
 

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -1,0 +1,40 @@
+package downloader_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	photoslibrary "google.golang.org/api/photoslibrary/v1"
+)
+
+// TestMediaItemFileName Test to ensure that JSON with `FileName` will be
+// populated under Media Item File Name
+func TestMediaItemFileName(t *testing.T) {
+	data := `
+	{
+		"baseUrl": "https://lh3.googleusercontent.com/1234",
+		"id": "1234",
+		"mediaMetadata": {
+			"creationTime": "2019-10-13T17:33:43Z",
+			"height": "3024",
+			"photo": {
+				"apertureFNumber": 1.7,
+				"cameraMake": "motorola",
+				"cameraModel": "Moto G (5) Plus",
+				"focalLength": 4.28,
+				"isoEquivalent": 400
+			},
+			"width": "4032"
+		},
+		"mimeType": "image/jpeg",
+		"productUrl": "https://photos.google.com/1234",
+		"filename": "IMG_1234.jpg"
+	}
+	`
+	item := new(photoslibrary.MediaItem)
+	json.Unmarshal([]byte(data), item)
+
+	if item.FileName != "IMG_1234.jpg" {
+		t.Errorf("photoslibrary.MediaItem.FileName = %v; want \"IMG_1234.jpg\"", item.FileName)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -114,11 +114,12 @@ func process() error {
 }
 
 func main() {
+	workingDirectory, _ := os.Getwd()
 	log.Println("This is gitmoo-goog ver", Version)
 	flag.BoolVar(&options.loop, "loop", false, "loops forever (use as daemon)")
 	flag.BoolVar(&options.ignoreerrors, "force", false, "ignore errors, and force working")
 	flag.StringVar(&options.logfile, "logfile", "", "log to this file")
-	flag.StringVar(&downloader.Options.BackupFolder, "folder", "", "backup folder")
+	flag.StringVar(&downloader.Options.BackupFolder, "folder", workingDirectory, "backup folder")
 	flag.StringVar(&downloader.Options.AlbumID, "album", "", "download only from this album (use google album id)")
 	flag.IntVar(&downloader.Options.MaxItems, "max", math.MaxInt32, "max items to download")
 	flag.IntVar(&downloader.Options.PageSize, "pagesize", 50, "number of items to download on per API call")

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -124,6 +125,8 @@ func main() {
 	flag.IntVar(&downloader.Options.MaxItems, "max", math.MaxInt32, "max items to download")
 	flag.IntVar(&downloader.Options.PageSize, "pagesize", 50, "number of items to download on per API call")
 	flag.IntVar(&downloader.Options.Throttle, "throttle", 5, "Time, in seconds, to wait between API calls")
+	flag.StringVar(&downloader.Options.FolderFormat, "folder-format", filepath.Join("2006", "January"), "Time format used for folder paths based on https://golang.org/pkg/time/#Time.Format")
+	flag.BoolVar(&downloader.Options.UseFileName, "use-file-name", false, "Use file name when uploaded to Google Photos")
 
 	flag.Parse()
 	if options.logfile != "" {

--- a/vendor/google.golang.org/api/photoslibrary/v1/photoslibrary-gen.go
+++ b/vendor/google.golang.org/api/photoslibrary/v1/photoslibrary-gen.go
@@ -1072,6 +1072,11 @@ type MediaItem struct {
 	// the user if they're signed in.
 	ProductUrl string `json:"productUrl,omitempty"`
 
+	// WARNING! This block had to be added to enable this field!
+	// FileName: Filename of the media item. This is shown to the user in the 
+	// item's info section in the Google Photos app.
+	FileName string `json:"filename,omitempty"`
+
 	// ServerResponse contains the HTTP response code and headers from the
 	// server.
 	googleapi.ServerResponse `json:"-"`


### PR DESCRIPTION
Helps with #4.

* **Add to vendor file FileName so it can be enabled in Photo Library API responses** (I could see no other way to do this)
* Moved JSON files to hidden file scheme and named using item identifier
* Store files using file name provided by the API response
* Added conflict handling when multiple files use the same name
* Changed to use digit month instead of name (e.g. Sept -> 09)

These are major changes and any existing library would not be able to use it.

Let me know what you think.