### PR TITLE
Added option to include exif metadata in pictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Usage of ./gitmoo-goog:
         Time format used for folder paths based on https://golang.org/pkg/time/#Time.Format (default "2016/Janurary")
   -use-file-name
         Use file name when uploaded to Google Photos (default off)
+  -include-exif
+        Retain EXIF metadata on downloaded images. Location information is not included because Google does not include it. (default off)
   -download-throttle
         Rate in KB/sec, to limit downloading of items (default off)
   -concurrent-downloads
@@ -83,10 +85,10 @@ Usage of ./gitmoo-goog:
 On Linux, running the following is a good practice:
 
 ```
-$ ./gitmoo-goog -folder archive -logfile gitmoo.log -loop -throttle 45 &
+$ ./gitmoo-goog -folder archive -logfile gitmoo.log -use-file-name -include-exif -loop -throttle 45 &
 ```
 
-This will start the process in background, making an API call every 45 seconds, looping forever on all items and saving them to `{pwd}/archive`. 
+This will start the process in background, making an API call every 45 seconds, looping forever on all items and saving them to `{pwd}/archive`. All images will be downloaded with a filename and metadata as close to original as Google offers through the api.
 
 Logfile will be saved as `gitmoo.log`.
 

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -208,7 +208,11 @@ func (d *Downloader) downloadImage(item *LibraryItem, filePath string) error {
 	if strings.HasPrefix(strings.ToLower(item.MediaItem.MimeType), "video") {
 		url = item.MediaItem.BaseUrl + "=dv"
 	} else {
-		url = fmt.Sprintf("%v=w%v-h%v", item.MediaItem.BaseUrl, item.MediaItem.MediaMetadata.Width, item.MediaItem.MediaMetadata.Height)
+		if d.Options.IncludeEXIF {
+			url = fmt.Sprintf("%v=d", item.MediaItem.BaseUrl)
+		} else {
+			url = fmt.Sprintf("%v=w%v-h%v", item.MediaItem.BaseUrl, item.MediaItem.MediaMetadata.Width, item.MediaItem.MediaMetadata.Height)
+		}
 	}
 	output, err := os.Create(filePath)
 	if err != nil {

--- a/downloader/options.go
+++ b/downloader/options.go
@@ -9,6 +9,8 @@ type Options struct {
 	FolderFormat string
 	//UseFileName use file name when uploaded to Google Photos
 	UseFileName bool
+	//OriginalFiles retain EXIF metadata on downloaded images. Location information is not included.
+	IncludeEXIF bool
 	//MaxItems how many items to download
 	MaxItems int
 	//number of items to download on per API call

--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func main() {
 	flag.IntVar(&downloader.Options.Throttle, "throttle", 5, "time, in seconds, to wait between API calls")
 	flag.StringVar(&downloader.Options.FolderFormat, "folder-format", filepath.Join("2006", "January"), "time format used for folder paths based on https://golang.org/pkg/time/#Time.Format")
 	flag.BoolVar(&downloader.Options.UseFileName, "use-file-name", false, "use file name when uploaded to Google Photos")
+	flag.BoolVar(&downloader.Options.IncludeEXIF, "include-exif", false, "retain EXIF metadata on downloaded images. Location information is not included.")
 	flag.Float64Var(&downloader.Options.DownloadThrottle, "download-throttle", 0, "rate in KB/sec, to limit downloading of items")
 	flag.IntVar(&downloader.Options.ConcurrentDownloads, "concurrent-downloads", 5, "number of concurrent item downloads")
 


### PR DESCRIPTION
Earlier an attempt was made to include exif in pictures, see #6. At that time the `=d` option had undesirable side-effects, see #7. After some testing I can conclude that the low-resolution issue has been resolved at Google's end. Now, when adding `=d`, the picture is downloaded in it's full, original resolution.

To not change existing behavior I added a flag to enable downloading of pictures with EXIF metadata.

Personally I think it would make more sense rely fully on the EXIF metadata and have a flag that enables writing json metadata files. However, this would be a major change and out of scope for this pr.