### PR TITLE
Add -version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Usage of ./gitmoo-goog:
         backup folder (default current working directory)
   -force
         ignore errors, and force working
+  -version
+        at startup, print the gitmoo-goog version
   -logfile string
         log to this file
   -credentials-file string

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var options struct {
 	loop         bool
 	logfile      string
 	ignoreerrors bool
+	version      bool
 }
 
 // Retrieve a token, saves the token, then returns the generated client.
@@ -115,10 +116,10 @@ func process(downloader *downloader.Downloader) error {
 func main() {
 	workingDirectory, _ := os.Getwd()
 	downloader := downloader.NewDownloader()
-	log.Println("This is gitmoo-goog ver", version.Version)
 	flag.BoolVar(&options.loop, "loop", false, "loops forever (use as daemon)")
 	flag.BoolVar(&options.ignoreerrors, "force", false, "ignore errors, and force working")
 	flag.StringVar(&options.logfile, "logfile", "", "log to this file")
+	flag.BoolVar(&options.version, "version", false, "at startup, print the gitmoo-goog version")
 	flag.StringVar(&downloader.Options.BackupFolder, "folder", workingDirectory, "backup folder")
 	flag.StringVar(&downloader.Options.AlbumID, "album", "", "download only from this album (use google album id)")
 	flag.IntVar(&downloader.Options.MaxItems, "max", math.MaxInt32, "max items to download")
@@ -145,6 +146,11 @@ func main() {
 			}
 		}()
 	}
+
+	if options.version {
+		log.Println("This is gitmoo-goog ver", version.Version)
+	}
+
 	err := process(downloader)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
Adds the `-version` flag that shows the gitmoo-goog version at startup. By default the version is no longer printed at starutp.

I believe this resolves #20