### PR TITLE
Remove Google OAuth OOB, add loopback server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ The zip contains Windows, Linux and MAC OS binaries.
 ### Configure gitmoo-goog:
 
 * Copy the downloaded `credentials.json` to the same folder with `gitmoo-goog`.
-* run `gitmoo-goog`, and follow the provided link
+* Run `gitmoo-goog`, and follow the provided link.
 * Sign in, and click `Allow`.
-* Copy the `token` and paste it in the cli.
-* `gitmoo-goog` will authorize and start downloading content. 
+* You will be redirected to a local address and it `This browser window can be now closed...`.
+* `gitmoo-goog` will authorize and start downloading content (authorization code will be automically received). 
 ```
 $ ./gitmoo-goog
 2018/09/12 10:18:07 This is gitmoo-goog ver 0.1

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Usage of ./gitmoo-goog:
         Rate in KB/sec, to limit downloading of items (default off)
   -concurrent-downloads
         Number of concurrent item downloads (default 5)
+  -loopback-port
+        Port number bound on `127.0.0.1` to receive auth code during authentication (default 8080)
 ```
 
 On Linux, running the following is a good practice:

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The zip contains Windows, Linux and MAC OS binaries.
 
 ### Configure gitmoo-goog:
 
-* Copy the downloaded `credentials.json` to the same folder with `gitmoo-goog` .
-* run `gitmoo-goog`, and follow the provided link:
-* Sign in, and click `Allow`
+* Copy the downloaded `credentials.json` to the same folder with `gitmoo-goog`.
+* run `gitmoo-goog`, and follow the provided link
+* Sign in, and click `Allow`.
 * Copy the `token` and paste it in the cli.
 * `gitmoo-goog` will authorize and start downloading content. 
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The zip contains Windows, Linux and MAC OS binaries.
 * Click on `Enable the Google Photos API` button
 * Create a new project, name it whatever you like.
 * Write `gitmoo-goog` in the `product name` field, (can be whatever you like)
-* On the `when are you calling from`, choose `Other`, click `Create`.
+* On the `when are you calling from`, choose `Desktop app`, click `Create`.
 * Download the client configuration.
 
 ### Configure gitmoo-goog:

--- a/main.go
+++ b/main.go
@@ -55,9 +55,8 @@ func getTokenFromWeb(config *oauth2.Config) *oauth2.Token {
 	var authCode string
 	_, err = fmt.Scanln(&authCode)
 
-	// Shutdown server since reading authorization code is complete
-	log.Println("Here")
-	server.Close() //.Shutdown(context.Background())
+	// Shutdown loopback server since reading authorization code is complete
+	defer server.Shutdown(context.Background())
 
 	if err != nil {
 		log.Fatalf("Unable to read authorization code: %v", err)
@@ -86,7 +85,11 @@ func startLoopbackServer() (*http.Server, error) {
 
 	http.HandleFunc("/", handler)
 	server := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%v", options.loopbackPort), Handler: nil}
-	return server, server.ListenAndServe()
+	go func() {
+		server.ListenAndServe()
+	}()
+
+	return server, nil
 }
 
 // Retrieves a token from a local file.


### PR DESCRIPTION
Fixes #25.

Adds a loopback server that spins up when starting the authentication process so the auth code can be pulled directly from the callback.

https://developers.google.com/identity/protocols/oauth2/resources/oob-migration
https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html