### PR TITLE
Fix broken release pipeline

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,28 +28,16 @@ jobs:
         GOOS=darwin go build -o gitmoo-goog-osx -ldflags "-s -w"
         go build -ldflags "-s -w"
         cd installer
-        go build 
+        go build
         ./installer
         cd ..
         zip gitmoo-goog.zip installer/*.deb gitmoo-goog-osx gitmoo-goog.exe
-        
+
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: ncipollo/release-action@v1
+      if: startsWith(github.ref, 'refs/tags/')
       with:
-        tag_name: 0.25
-        release_name: Release 0.25
-        draft: true          
-        
-    - name: Upload Release Asset
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} 
-          asset_path: ./gitmoo-goog.zip
-          asset_name: gitmoo-goog.zip
-          asset_content_type: application/zip
+        artifacts: "gitmoo-goog.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: true


### PR DESCRIPTION
Replace the unmaintained 'actions/create-release' step with 'ncipollo/release-action'.

Hopefully this allows us to start merging prs and creating releases again :smile: 